### PR TITLE
Mulf does not work when money amount is 5 or more digits. 

### DIFF
--- a/money.go
+++ b/money.go
@@ -26,7 +26,6 @@ var (
 	ErrMoneyZeroOrLessChunks      = errors.New("i18n: cannot split money into zero or less chunks")
 
 	Guardi int     = 100
-	Guard  int64   = int64(Guardi)
 	Guardf float64 = float64(Guardi)
 	DP     int64   = 100         // for default of 2 decimal places => 10^2 (can be reset)
 	DPf    float64 = float64(DP) // for default of 2 decimal places => 10^2 (can be reset)
@@ -137,9 +136,19 @@ func (m Money) Mul(n Money) Money {
 
 // Multiplies a Money with a float to return a money-stored type.
 func (m Money) Mulf(f float64) Money {
-	i := m.M * int64(f*Guardf*DPf)
-	r := i / Guard / DP
-	return Money{C: m.C, M: Rnd(r, float64(i)/Guardf/DPf-float64(r))}
+	guard := int64(10)
+	//calculate how many digits are in m.M
+	n := m.M
+	for n > 1 {
+		guard = guard * 10
+		n = n / 10
+	}
+	guardf := float64(guard)
+
+	i := m.M * int64(f*guardf)
+	r := i / guard
+
+	return Money{C: m.C, M: Rnd(r, float64(i)/guardf-float64(r))}
 }
 
 // Returns the negative value of Money.

--- a/money_test.go
+++ b/money_test.go
@@ -54,11 +54,43 @@ func TestMul(t *testing.T) {
 }
 
 func TestMulf(t *testing.T) {
-	m1 := Money{123, "EUR"}
-	m2 := 2.0
-	m3 := m1.Mulf(m2)
-	if m3.Get() != 2.46 {
-		t.Errorf("expected money amount to be %v, got %v", 2.46, m3.Get())
+	var fixtures = []struct {
+		money      Money
+		multiplier float64
+		expResult  float64
+	}{
+		{
+			money:      Money{123, "EUR"},
+			multiplier: 2.0,
+			expResult:  2.46,
+		},
+		{
+			money:      Money{1234, "EUR"},
+			multiplier: 2.26,
+			expResult:  27.89,
+		},
+		{
+			money:      Money{12345, "EUR"},
+			multiplier: 2.26,
+			expResult:  279,
+		},
+		{
+			money:      Money{123456, "EUR"},
+			multiplier: 2.26,
+			expResult:  2790.11,
+		},
+		{
+			money:      Money{123456, "EUR"},
+			multiplier: 7 / 12.0,
+			expResult:  720.16,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		got := fixture.money.Mulf(fixture.multiplier).Get()
+		if got != fixture.expResult {
+			t.Errorf("expected money amount to be %v, got %v", fixture.expResult, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Halo! :) As far as I understand, this is because we are using 10000 constant to drive precision, but if m.M is in fact 10000 or higher, it will make the parts we are cutting off assuming they are < cents more than cents.

To fix, calculate the power of 10 the guard needs to be based on m.M and use that.
Added some tests that fail on previous implementation.
Could use Log10 math function to calculate power of ten, but I think it's more confusing that way. 