### PR TITLE
Get string representation without currency

### DIFF
--- a/money.go
+++ b/money.go
@@ -209,6 +209,15 @@ func (m Money) String() string {
 	return fmt.Sprintf("-%d.%02d %s", m.Abs().Value()/m.dp(), m.Abs().Value()%m.dp(), m.C)
 }
 
+// String for money type representation in basic monetary unit (DOLLARS CENTS) without currency.
+func (m Money) UnitAsString() string {
+	if m.Sign() > 0 {
+		return fmt.Sprintf("%d.%02d", m.Value()/m.dp(), m.Value()%m.dp())
+	}
+	// Negative value
+	return fmt.Sprintf("-%d.%02d", m.Abs().Value()/m.dp(), m.Abs().Value()%m.dp())
+}
+
 func (m Money) Format(locale string) string {
 	l, found := Locales[locale]
 	if !found {

--- a/money_test.go
+++ b/money_test.go
@@ -623,3 +623,35 @@ func TestJSONUnmarshal(t *testing.T) {
 		}
 	}
 }
+
+func TestUnitAsString(t *testing.T) {
+	var fixtures = []struct {
+		m        Money
+		expected string
+	}{
+		{Money{0, "EUR"}, "0.00"},
+		{Money{1, "EUR"}, "0.01"},
+		{Money{12, "EUR"}, "0.12"},
+		{Money{123, "EUR"}, "1.23"},
+		{Money{1234, "EUR"}, "12.34"},
+		{Money{100000, "EUR"}, "1000.00"},
+		{Money{123456, "EUR"}, "1234.56"},
+		{Money{1234567, "EUR"}, "12345.67"},
+		{Money{1234567890, "EUR"}, "12345678.90"},
+		{Money{-1, "EUR"}, "-0.01"},
+		{Money{-12, "EUR"}, "-0.12"},
+		{Money{-123, "EUR"}, "-1.23"},
+		{Money{-1234, "EUR"}, "-12.34"},
+		{Money{-100000, "EUR"}, "-1000.00"},
+		{Money{-123456, "EUR"}, "-1234.56"},
+		{Money{-1234567, "EUR"}, "-12345.67"},
+		{Money{-1234567890, "EUR"}, "-12345678.90"},
+	}
+
+	for _, f := range fixtures {
+		got := f.m.UnitAsString()
+		if got != f.expected {
+			t.Errorf("expected %s, got %s", f.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
Add a function that returns a string representation of the `Money` structure without currency.